### PR TITLE
Fix MIME types

### DIFF
--- a/lib/favicon_party/image.rb
+++ b/lib/favicon_party/image.rb
@@ -24,6 +24,8 @@ module FaviconParty
       image/svg+xml
       image/jpeg
       image/x-ms-bmp
+      image/bmp
+      image/vnd.microsoft.icon
     )
 
     attr_accessor :source_data, :png_data, :error

--- a/test/image_test.rb
+++ b/test/image_test.rb
@@ -32,7 +32,7 @@ class ImageTest < Minitest::Test
 
   def test_x_ms_bmp_is_valid
     @image = @klass.new read_fixture("favicons/specimens/x-ms-bmp.ico")
-    assert @image.mime_type == "image/x-ms-bmp"
+    assert @image.mime_type == "image/bmp"
     assert @image.valid_mime_type?
   end
 

--- a/test/utils_test.rb
+++ b/test/utils_test.rb
@@ -15,7 +15,7 @@ class UtilsTest < Minitest::Test
 
   def test_get_mime_type_detects_ico_correctly
     data = read_fixture("favicons/white-16x16.ico", "rb")
-    assert %w( image/x-ico image/x-icon ).include? get_mime_type(data)
+    assert %w( image/x-ico image/x-icon image/vnd.microsoft.icon ).include? get_mime_type(data)
   end
 
   def test_get_mime_type_detects_svg_correctly


### PR DESCRIPTION
This pull request updates the MIME types due to changes in the out from the `file` utility. It appears as though the `.ico` type was changed to `image/vnd.microsoft.icon` in https://github.com/file/file/commit/63b17e62e3aeaf4eb22564538e9041402974ad49 even though it doesn't [seem correct](https://en.wikipedia.org/wiki/ICO_(file_format)#MIME_type).