### PR TITLE
Add Ruby 3 support

### DIFF
--- a/lib/favicon_party/fetcher.rb
+++ b/lib/favicon_party/fetcher.rb
@@ -1,5 +1,6 @@
 require 'base64'
 require 'nokogiri'
+require 'webrick'
 
 
 module FaviconParty
@@ -81,7 +82,7 @@ module FaviconParty
       }
       uri = URI final_url
       candidate_urls.map! do |href|
-        href = URI.encode(URI.decode(href.strip))
+        href = WEBrick::HTTPUtils.escape(WEBrick::HTTPUtils.unescape(href.strip))
         if href =~ /\A\/\//
           href = "#{uri.scheme}:#{href}"
         elsif href !~ /\Ahttp/
@@ -110,11 +111,11 @@ module FaviconParty
       location = final_location(FaviconParty::HTTPClient.head(@query_url))
       if !location.nil?
         if location =~ /\Ahttp/
-          @final_url = URI.encode location
+          @final_url = WEBrick::HTTPUtils.escape location
         else
           uri = URI @query_url
           root = "#{uri.scheme}://#{uri.host}"
-          @final_url = URI.encode URI.join(root, location).to_s
+          @final_url = WEBrick::HTTPUtils.escape URI.join(root, location).to_s
         end
       end
       if !@final_url.nil?

--- a/lib/favicon_party/utils.rb
+++ b/lib/favicon_party/utils.rb
@@ -1,13 +1,13 @@
-require 'uri'
 require 'tempfile'
+require 'webrick'
 
 module FaviconParty
   module Utils
     def prefix_url(url, options = {})
       unless options[:downcase] == false
-        url = URI.encode URI.decode(url.strip.downcase)
+        url = WEBrick::HTTPUtils.escape WEBrick::HTTPUtils.unescape(url.strip.downcase)
       else
-        url = URI.encode URI.decode(url.strip)
+        url = WEBrick::HTTPUtils.escape WEBrick::HTTPUtils.unescape(url.strip)
       end
       if url =~ /https?:\/\//
         url

--- a/test/utils_test.rb
+++ b/test/utils_test.rb
@@ -45,7 +45,7 @@ class UtilsTest < Minitest::Test
 
   def test_prefix_url_does_not_reencode_encoded_url
     url = "http://cdn6.bigcommerce.com/s-xe95b6v/product_images/Beep_SocialMedia_1%20(2).jpg"
-    assert URI.decode(url) != url
+    assert WEBrick::HTTPUtils.unescape(url) != url
     assert prefix_url(url, :downcase => false) == url
   end
 end


### PR DESCRIPTION
This pull request replaces the `URI.encode` and `URI.decode` methods to run on Ruby 3.